### PR TITLE
Default Gemini model to latest for AI backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Google AI Studio / Gemini API key
+GOOGLE_AI_STUDIO_API_KEY=your_api_key_here
+
+# Optional: override the default Gemini model (gemini-1.5-flash-latest)
+# GOOGLE_AI_MODEL=gemini-1.5-pro
+
+# Optionally change the port for the Express server
+# PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Optional editor directories and files
+.vscode/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Caption & Hashtag Generator
+
+This project is a multi-brand Instagram caption and hashtag generator with an AI-assisted backend powered by Google AI Studio (Gemini). It lets you select a brand, upload an optional image, describe the post you want to share, and receive polished captions and hashtag sets tailored to the brand.
+
+## Prerequisites
+
+- Node.js 18 or newer (for native `fetch` support) or Node.js 16+ with the provided `node-fetch` fallback.
+- A Google AI Studio (Generative Language / Gemini) API key.
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Copy the environment template and add your API key:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Edit `.env` and set `GOOGLE_AI_STUDIO_API_KEY` to your Google AI Studio key. The user-provided key can be placed here.
+
+3. Start the Express server:
+
+   ```bash
+   npm start
+   ```
+
+4. Open the application:
+
+   Visit [http://localhost:3000](http://localhost:3000) in your browser. The frontend will fetch brand metadata from `brandData.json` and use the `/api/generate` endpoint to request AI-generated captions and hashtags.
+
+## API Notes
+
+- The backend calls the `gemini-1.5-flash-latest` model via Google AI Studio by default. You can override the model with the `GOOGLE_AI_MODEL` environment variable if your project has access to a different release channel.
+- Requests include optional inline image data when an image is uploaded.
+- Responses are normalized to ensure the frontend always receives caption and hashtag arrays.
+
+## Environment Variables
+
+- `GOOGLE_AI_STUDIO_API_KEY`: (Required) Your Google AI Studio API key. Alternately you can use `GOOGLE_API_KEY` or `GOOGLE_STUDIO_API_KEY` for compatibility.
+- `GOOGLE_AI_MODEL`: (Optional) Set a specific Gemini model to call (defaults to `gemini-1.5-flash-latest`).
+- `PORT`: (Optional) Override the default Express port (3000).
+
+## Troubleshooting
+
+- **`Gemini API 404: Method not found`** – Ensure the `GOOGLE_AI_MODEL` value matches a model that is available to your API key. The default of `gemini-1.5-flash-latest` works for the Google AI Studio free tier. If you previously set a different model, update or remove the override and restart the server.
+
+## Development Tips
+
+- Brand configuration lives in `brandData.json` and is shared between the frontend and backend.
+- AI usage metadata (token counts and optional notes) is displayed in the UI when available.
+- If the AI response is malformed, the backend provides deterministic fallbacks using the brand configuration.

--- a/app.js
+++ b/app.js
@@ -1,152 +1,35 @@
-// Brand data and configuration
-const brandData = {
-  "brands": [
-    {
-      "id": "furniturehub12",
-      "name": "Furniture Hub 12",
-      "description": "Modern, industrial furniture for cafes and offices",
-      "industry": "Modern Furniture (India)",
-      "tone": "Professional, Industrial, Modern",
-      "target": "Cafes, Offices, Restaurants",
-      "keywords": ["Quality", "Stylish", "Industrial", "Modern furniture", "Workspace", "Office design"],
-      "website": "www.Exportofindia.com",
-      "hashtags": ["#ModernFurniture", "#IndustrialStyle", "#OfficeDesign", "#WorkspaceGoals", "#FurnitureDesign", "#InteriorDesign"],
-      "sampleCaptions": [
-        "Transform your workspace with industrial elegance ⚡",
-        "Where modern meets functional - office furniture redefined 🏢",
-        "Elevate your cafe's ambiance with our signature pieces ☕"
-      ]
-    },
-    {
-      "id": "asian_bazaar",
-      "name": "Asian Bazaar",
-      "description": "Vintage and historical aesthetic modern furniture",
-      "industry": "Vintage Decor & Modern Furniture",
-      "tone": "Aesthetic, Historical, Trendy",
-      "target": "Home decorators, Vintage enthusiasts",
-      "keywords": ["Vintage", "Modern", "Historical aesthetics", "Sydney warehouse", "Decor"],
-      "website": "https://asian-bazaar.com.au/",
-      "hashtags": ["#VintageFurniture", "#HistoricalDesign", "#ModernVintage", "#HomeDecor", "#AntiqueStyle", "#VintageDecor"],
-      "sampleCaptions": [
-        "Where history meets contemporary living ✨",
-        "Vintage soul, modern heart - furniture with stories to tell 📚",
-        "Transform your space with timeless elegance 🏛️"
-      ]
-    },
-    {
-      "id": "exportofindia",
-      "name": "Export of India",
-      "description": "Premium, durable, customizable furniture",
-      "industry": "Premium Furniture",
-      "tone": "Premium, Trustworthy, Quality-focused",
-      "target": "Quality-conscious buyers",
-      "keywords": ["Premium", "Durable", "Stylish", "Customizable", "Quality"],
-      "website": "www.Exportofindia.com",
-      "hashtags": ["#PremiumFurniture", "#QualityCraftsmanship", "#CustomFurniture", "#DurableDesign", "#LuxuryLiving", "#IndianCraftsmanship"],
-      "sampleCaptions": [
-        "Premium quality that stands the test of time 💎",
-        "Crafted with precision, designed for elegance 🎯",
-        "Your vision, our craftsmanship - furniture that speaks quality ⭐"
-      ]
-    },
-    {
-      "id": "blissofwellness",
-      "name": "Bliss of Wellness",
-      "description": "Air fresheners for cars, promoting wellness",
-      "industry": "Wellness & Air Fresheners",
-      "tone": "Natural, Calming, Health-focused",
-      "target": "Car owners, Wellness enthusiasts",
-      "keywords": ["Nature", "Comfort", "Air fresheners", "Wellness", "Cars", "Freshness"],
-      "website": "Blissofwellness.com",
-      "hashtags": ["#CarWellness", "#NaturalFreshness", "#AirFreshener", "#WellnessJourney", "#HealthyLiving", "#CarEssentials"],
-      "sampleCaptions": [
-        "Breathe better, drive happier 🌿",
-        "Transform your daily commute into a wellness journey 🚗💚",
-        "Natural freshness that travels with you ✨"
-      ]
-    },
-    {
-      "id": "hotel_kspalace",
-      "name": "Hotel KS Palace",
-      "description": "Luxury boutique hotel in Srinagar",
-      "industry": "Luxury Boutique Hotel (Srinagar)",
-      "tone": "Luxury, Relaxing, Hospitality-focused",
-      "target": "Solo, couple, family travelers",
-      "keywords": ["Luxury", "Srinagar", "Boutique hotel", "Kashmir", "Hospitality"],
-      "website": "",
-      "hashtags": ["#LuxuryHotel", "#SrinagarStay", "#KashmirHospitality", "#BoutiqueHotel", "#LuxuryTravel", "#KashmirTourism"],
-      "sampleCaptions": [
-        "Where even the Wi-Fi signals relax 📶✨",
-        "Luxury redefined in the heart of Srinagar 🏔️",
-        "Your sanctuary in paradise awaits 🌸"
-      ]
-    },
-    {
-      "id": "houseboat_holidays_kashmir",
-      "name": "Houseboat Holidays Kashmir",
-      "description": "Deluxe houseboats in Srinagar",
-      "industry": "Deluxe Houseboat Tourism",
-      "tone": "Hospitality, Scenic, Cultural",
-      "target": "Tourists, Experience seekers",
-      "keywords": ["Deluxe", "Nigeen lake", "Kashmiri hospitality", "Floating paradise", "Houseboat"],
-      "website": "",
-      "hashtags": ["#HouseboatStay", "#KashmirTourism", "#NigeenLake", "#FloatingParadise", "#KashmirHospitality", "#UniqueStay"],
-      "sampleCaptions": [
-        "Float into serenity on Nigeen Lake 🚤",
-        "Where water meets wanderlust - your floating paradise awaits 🌊",
-        "Experience Kashmir like never before ⛵"
-      ]
-    },
-    {
-      "id": "valleyweddingcars",
-      "name": "Valley Wedding Cars",
-      "description": "Luxury car rentals for weddings and events",
-      "industry": "Luxury Car Rentals",
-      "tone": "Luxury, Celebratory, Premium service",
-      "target": "Wedding couples, Event organizers",
-      "keywords": ["Luxury cars", "Wedding", "Engagement", "Sightseeing", "Proposal", "Kashmir"],
-      "website": "",
-      "hashtags": ["#LuxuryCars", "#KashmirWeddings", "#WeddingCars", "#LuxuryRentals", "#DreamWedding", "#ValleyWeddings"],
-      "sampleCaptions": [
-        "Arrive in style on your special day 💍🚗",
-        "Every love story deserves a luxury entrance ✨",
-        "Making your dream wedding a reality, one ride at a time 👰🤵"
-      ]
-    }
-  ],
-  "trendingHashtags2025": [
-    "#trending", "#viral", "#instagram", "#instagood", "#explore", "#reels", 
-    "#september2025", "#autumn", "#fall", "#photography", "#photooftheday", 
-    "#love", "#nature", "#travel", "#lifestyle", "#business", "#fashion", 
-    "#beauty", "#fitness", "#food", "#art", "#design", "#inspiration", 
-    "#motivation", "#success", "#entrepreneur", "#smallbusiness", "#local", 
-    "#handmade", "#quality", "#luxury", "#premium", "#style", "#modern", 
-    "#vintage", "#classic", "#unique", "#special", "#amazing", "#beautiful"
-  ],
-  "industryHashtags": {
-    "furniture": ["#furniture", "#homedecor", "#interiordesign", "#homedesign", "#decor", "#home", "#design", "#interior", "#decoration", "#living", "#bedroom", "#kitchen", "#office", "#workspace"],
-    "wellness": ["#wellness", "#health", "#natural", "#organic", "#fresh", "#clean", "#comfort", "#relax", "#breathe", "#mindfulness", "#selfcare", "#healthy"],
-    "tourism": ["#travel", "#tourism", "#vacation", "#holiday", "#destination", "#explore", "#adventure", "#experience", "#journey", "#wanderlust", "#getaway", "#staycation"],
-    "automotive": ["#cars", "#luxury", "#rental", "#wedding", "#event", "#celebration", "#special", "#premium", "#service", "#transportation", "#ride", "#style"]
-  },
-  "locationHashtags": {
-    "kashmir": ["#kashmir", "#srinagar", "#kashmirtourism", "#kashmirvalley", "#paradiseonearth", "#kashmirbeuty", "#incredibleindia"],
-    "india": ["#india", "#incredibleindia", "#madeinindia", "#indian", "#desi", "#bharath", "#hindustan"],
-    "sydney": ["#sydney", "#australia", "#sydneyaustralia", "#sydneyharbour", "#aussie", "#downunder"]
-  }
-};
+// Brand data and configuration (loaded from external JSON file)
+let brandData = null;
 
 // Application State
 let currentBrand = null;
 let uploadedImage = null;
+let uploadedImageDataUrl = null;
 
 // Initialize the application
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', async function() {
     console.log('Initializing Caption and Hashtag Generator...');
-    initializeBrandSelector();
+    await loadBrandData();
     initializeEventListeners();
     updateGenerateButton();
 });
+
+// Fetch brand data from the backend
+async function loadBrandData() {
+    try {
+        const response = await fetch('brandData.json', { cache: 'no-cache' });
+        if (!response.ok) {
+            throw new Error(`Failed to load brand data: ${response.status}`);
+        }
+
+        brandData = await response.json();
+        console.log('Brand data loaded with', brandData.brands?.length || 0, 'entries');
+        initializeBrandSelector();
+    } catch (error) {
+        console.error('Error loading brand data:', error);
+        showToast('Unable to load brand information. Please refresh the page.', 'error');
+    }
+}
 
 // Initialize brand selector dropdown
 function initializeBrandSelector() {
@@ -155,7 +38,12 @@ function initializeBrandSelector() {
         console.error('Brand select element not found');
         return;
     }
-    
+
+    if (!brandData || !Array.isArray(brandData.brands)) {
+        console.warn('Brand data not available yet');
+        return;
+    }
+
     // Clear existing options except the first one
     while (brandSelect.children.length > 1) {
         brandSelect.removeChild(brandSelect.lastChild);
@@ -219,12 +107,17 @@ function initializeEventListeners() {
 function handleBrandChange() {
     const brandSelect = document.getElementById('brandSelect');
     const brandDescription = document.getElementById('brandDescription');
-    
+
     if (!brandSelect || !brandDescription) {
         console.error('Brand selection elements not found');
         return;
     }
-    
+
+    if (!brandData || !Array.isArray(brandData.brands)) {
+        console.warn('Brand data not ready when handling selection');
+        return;
+    }
+
     const brandId = brandSelect.value;
     currentBrand = brandData.brands.find(brand => brand.id === brandId);
     
@@ -329,6 +222,7 @@ function handleImageFile(file) {
             uploadZone.classList.add('hidden');
             imagePreview.classList.remove('hidden');
             uploadedImage = file;
+            uploadedImageDataUrl = e.target.result;
             updateGenerateButton();
             console.log('Image uploaded successfully');
         }
@@ -347,8 +241,9 @@ function removeImage() {
     if (imagePreview) imagePreview.classList.add('hidden');
     if (previewImg) previewImg.src = '';
     if (imageInput) imageInput.value = '';
-    
+
     uploadedImage = null;
+    uploadedImageDataUrl = null;
     updateGenerateButton();
     console.log('Image removed');
 }
@@ -426,38 +321,56 @@ async function generateContent() {
         console.error('No brand selected');
         return;
     }
-    
+
     console.log('Starting content generation...');
-    
+
     // Show loading state
     const generateBtn = document.getElementById('generateBtn');
     const btnText = generateBtn?.querySelector('.btn-text');
     const btnSpinner = generateBtn?.querySelector('.btn-spinner');
-    
+
     if (btnText) btnText.classList.add('hidden');
     if (btnSpinner) btnSpinner.classList.remove('hidden');
     if (generateBtn) generateBtn.disabled = true;
-    
+
     try {
-        // Simulate API delay
-        await new Promise(resolve => setTimeout(resolve, 1500));
-        
-        // Generate captions and hashtags
-        const captions = generateCaptions();
-        const hashtags = generateHashtags();
-        
-        console.log('Generated captions:', captions.length);
-        console.log('Generated hashtag sets:', hashtags.length);
-        
-        // Display results
-        displayResults(captions, hashtags);
-        
-        // Show success message
+        const contextInput = document.getElementById('contextInput');
+        const contextText = contextInput ? contextInput.value.trim() : '';
+
+        const response = await fetch('/api/generate', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                brandId: currentBrand.id,
+                context: contextText,
+                imageDataUrl: uploadedImageDataUrl
+            })
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}));
+            const message = errorData.error || `Generation failed with status ${response.status}`;
+            throw new Error(message);
+        }
+
+        const result = await response.json();
+        const captions = (result.captions || []).map(caption => ({
+            ...caption,
+            length: caption.text ? caption.text.length : 0
+        }));
+        const hashtags = Array.isArray(result.hashtags) ? result.hashtags : [];
+
+        console.log('Generated captions via AI:', captions.length);
+        console.log('Generated hashtag sets via AI:', hashtags.length);
+
+        displayResults(captions, hashtags, result.metadata || null);
         showToast('Content generated successfully!', 'success');
-        
+
     } catch (error) {
         console.error('Generation error:', error);
-        showToast('Failed to generate content. Please try again.', 'error');
+        showToast(error.message || 'Failed to generate content. Please try again.', 'error');
     } finally {
         // Reset button state
         if (btnText) btnText.classList.remove('hidden');
@@ -620,8 +533,12 @@ function getCallToAction() {
 
 // Generate hashtag sets
 function generateHashtags() {
+    if (!brandData) {
+        return [];
+    }
+
     const hashtagSets = [];
-    
+
     // Brand-specific hashtags
     const brandHashtags = [...currentBrand.hashtags];
     hashtagSets.push({
@@ -686,18 +603,25 @@ function getLocationKey() {
 
 // Get random trending hashtags
 function getRandomTrendingHashtags() {
+    if (!brandData || !Array.isArray(brandData.trendingHashtags2025)) {
+        return [];
+    }
+
     const trending = [...brandData.trendingHashtags2025];
     const shuffled = trending.sort(() => 0.5 - Math.random());
     return shuffled.slice(0, 10);
 }
 
 // Display generated results
-function displayResults(captions, hashtags) {
+function displayResults(captions, hashtags, metadata = null) {
     const captionResults = document.getElementById('captionResults');
     const hashtagResults = document.getElementById('hashtagResults');
     const resultsContainer = document.getElementById('resultsContainer');
     const emptyState = document.getElementById('emptyState');
-    
+    const aiInsightsCard = document.getElementById('aiInsightsCard');
+    const aiNotes = document.getElementById('aiNotes');
+    const aiUsage = document.getElementById('aiUsage');
+
     if (!captionResults || !hashtagResults) {
         console.error('Results containers not found');
         return;
@@ -718,14 +642,48 @@ function displayResults(captions, hashtags) {
         const hashtagCard = createHashtagCard(hashtagSet, index);
         hashtagResults.appendChild(hashtagCard);
     });
-    
+
     // Show results, hide empty state
     if (emptyState) emptyState.classList.add('hidden');
     if (resultsContainer) {
         resultsContainer.classList.remove('hidden');
         resultsContainer.classList.add('fade-in');
     }
-    
+
+    if (aiInsightsCard && aiNotes && aiUsage) {
+        if (metadata && (metadata.notes || metadata.usage)) {
+            aiInsightsCard.classList.remove('hidden');
+
+            if (metadata.notes) {
+                aiNotes.textContent = metadata.notes;
+                aiNotes.classList.remove('hidden');
+            } else {
+                aiNotes.textContent = '';
+                aiNotes.classList.add('hidden');
+            }
+
+            const usage = metadata.usage;
+            if (usage && (usage.promptTokenCount !== undefined || usage.candidatesTokenCount !== undefined || usage.totalTokenCount !== undefined)) {
+                const usageParts = [];
+                if (usage.promptTokenCount !== undefined) usageParts.push(`Prompt tokens: ${usage.promptTokenCount}`);
+                if (usage.candidatesTokenCount !== undefined) usageParts.push(`Response tokens: ${usage.candidatesTokenCount}`);
+                if (usage.totalTokenCount !== undefined) usageParts.push(`Total tokens: ${usage.totalTokenCount}`);
+
+                aiUsage.textContent = usageParts.join(' • ');
+                aiUsage.classList.remove('hidden');
+            } else {
+                aiUsage.textContent = '';
+                aiUsage.classList.add('hidden');
+            }
+        } else {
+            aiInsightsCard.classList.add('hidden');
+            aiNotes.textContent = '';
+            aiNotes.classList.add('hidden');
+            aiUsage.textContent = '';
+            aiUsage.classList.add('hidden');
+        }
+    }
+
     console.log('Results displayed successfully');
 }
 

--- a/brandData.json
+++ b/brandData.json
@@ -1,0 +1,136 @@
+{
+  "brands": [
+    {
+      "id": "furniturehub12",
+      "name": "Furniture Hub 12",
+      "description": "Modern, industrial furniture for cafes and offices",
+      "industry": "Modern Furniture (India)",
+      "tone": "Professional, Industrial, Modern",
+      "target": "Cafes, Offices, Restaurants",
+      "keywords": ["Quality", "Stylish", "Industrial", "Modern furniture", "Workspace", "Office design"],
+      "website": "www.Exportofindia.com",
+      "hashtags": ["#ModernFurniture", "#IndustrialStyle", "#OfficeDesign", "#WorkspaceGoals", "#FurnitureDesign", "#InteriorDesign"],
+      "sampleCaptions": [
+        "Transform your workspace with industrial elegance ⚡",
+        "Where modern meets functional - office furniture redefined 🏢",
+        "Elevate your cafe's ambiance with our signature pieces ☕"
+      ]
+    },
+    {
+      "id": "asian_bazaar",
+      "name": "Asian Bazaar",
+      "description": "Vintage and historical aesthetic modern furniture",
+      "industry": "Vintage Decor & Modern Furniture",
+      "tone": "Aesthetic, Historical, Trendy",
+      "target": "Home decorators, Vintage enthusiasts",
+      "keywords": ["Vintage", "Modern", "Historical aesthetics", "Sydney warehouse", "Decor"],
+      "website": "https://asian-bazaar.com.au/",
+      "hashtags": ["#VintageFurniture", "#HistoricalDesign", "#ModernVintage", "#HomeDecor", "#AntiqueStyle", "#VintageDecor"],
+      "sampleCaptions": [
+        "Where history meets contemporary living ✨",
+        "Vintage soul, modern heart - furniture with stories to tell 📚",
+        "Transform your space with timeless elegance 🏛️"
+      ]
+    },
+    {
+      "id": "exportofindia",
+      "name": "Export of India",
+      "description": "Premium, durable, customizable furniture",
+      "industry": "Premium Furniture",
+      "tone": "Premium, Trustworthy, Quality-focused",
+      "target": "Quality-conscious buyers",
+      "keywords": ["Premium", "Durable", "Stylish", "Customizable", "Quality"],
+      "website": "www.Exportofindia.com",
+      "hashtags": ["#PremiumFurniture", "#QualityCraftsmanship", "#CustomFurniture", "#DurableDesign", "#LuxuryLiving", "#IndianCraftsmanship"],
+      "sampleCaptions": [
+        "Premium quality that stands the test of time 💎",
+        "Crafted with precision, designed for elegance 🎯",
+        "Your vision, our craftsmanship - furniture that speaks quality ⭐"
+      ]
+    },
+    {
+      "id": "blissofwellness",
+      "name": "Bliss of Wellness",
+      "description": "Air fresheners for cars, promoting wellness",
+      "industry": "Wellness & Air Fresheners",
+      "tone": "Natural, Calming, Health-focused",
+      "target": "Car owners, Wellness enthusiasts",
+      "keywords": ["Nature", "Comfort", "Air fresheners", "Wellness", "Cars", "Freshness"],
+      "website": "Blissofwellness.com",
+      "hashtags": ["#CarWellness", "#NaturalFreshness", "#AirFreshener", "#WellnessJourney", "#HealthyLiving", "#CarEssentials"],
+      "sampleCaptions": [
+        "Breathe better, drive happier 🌿",
+        "Transform your daily commute into a wellness journey 🚗💚",
+        "Natural freshness that travels with you ✨"
+      ]
+    },
+    {
+      "id": "hotel_kspalace",
+      "name": "Hotel KS Palace",
+      "description": "Luxury boutique hotel in Srinagar",
+      "industry": "Luxury Boutique Hotel (Srinagar)",
+      "tone": "Luxury, Relaxing, Hospitality-focused",
+      "target": "Solo, couple, family travelers",
+      "keywords": ["Luxury", "Srinagar", "Boutique hotel", "Kashmir", "Hospitality"],
+      "website": "",
+      "hashtags": ["#LuxuryHotel", "#SrinagarStay", "#KashmirHospitality", "#BoutiqueHotel", "#LuxuryTravel", "#KashmirTourism"],
+      "sampleCaptions": [
+        "Where even the Wi-Fi signals relax 📶✨",
+        "Luxury redefined in the heart of Srinagar 🏔️",
+        "Your sanctuary in paradise awaits 🌸"
+      ]
+    },
+    {
+      "id": "houseboat_holidays_kashmir",
+      "name": "Houseboat Holidays Kashmir",
+      "description": "Deluxe houseboats in Srinagar",
+      "industry": "Deluxe Houseboat Tourism",
+      "tone": "Hospitality, Scenic, Cultural",
+      "target": "Tourists, Experience seekers",
+      "keywords": ["Deluxe", "Nigeen lake", "Kashmiri hospitality", "Floating paradise", "Houseboat"],
+      "website": "",
+      "hashtags": ["#HouseboatStay", "#KashmirTourism", "#NigeenLake", "#FloatingParadise", "#KashmirHospitality", "#UniqueStay"],
+      "sampleCaptions": [
+        "Float into serenity on Nigeen Lake 🚤",
+        "Where water meets wanderlust - your floating paradise awaits 🌊",
+        "Experience Kashmir like never before ⛵"
+      ]
+    },
+    {
+      "id": "valleyweddingcars",
+      "name": "Valley Wedding Cars",
+      "description": "Luxury car rentals for weddings and events",
+      "industry": "Luxury Car Rentals",
+      "tone": "Luxury, Celebratory, Premium service",
+      "target": "Wedding couples, Event organizers",
+      "keywords": ["Luxury cars", "Wedding", "Engagement", "Sightseeing", "Proposal", "Kashmir"],
+      "website": "",
+      "hashtags": ["#LuxuryCars", "#KashmirWeddings", "#WeddingCars", "#LuxuryRentals", "#DreamWedding", "#ValleyWeddings"],
+      "sampleCaptions": [
+        "Arrive in style on your special day 💍🚗",
+        "Every love story deserves a luxury entrance ✨",
+        "Making your dream wedding a reality, one ride at a time 👰🤵"
+      ]
+    }
+  ],
+  "trendingHashtags2025": [
+    "#trending", "#viral", "#instagram", "#instagood", "#explore", "#reels",
+    "#september2025", "#autumn", "#fall", "#photography", "#photooftheday",
+    "#love", "#nature", "#travel", "#lifestyle", "#business", "#fashion",
+    "#beauty", "#fitness", "#food", "#art", "#design", "#inspiration",
+    "#motivation", "#success", "#entrepreneur", "#smallbusiness", "#local",
+    "#handmade", "#quality", "#luxury", "#premium", "#style", "#modern",
+    "#vintage", "#classic", "#unique", "#special", "#amazing", "#beautiful"
+  ],
+  "industryHashtags": {
+    "furniture": ["#furniture", "#homedecor", "#interiordesign", "#homedesign", "#decor", "#home", "#design", "#interior", "#decoration", "#living", "#bedroom", "#kitchen", "#office", "#workspace"],
+    "wellness": ["#wellness", "#health", "#natural", "#organic", "#fresh", "#clean", "#comfort", "#relax", "#breathe", "#mindfulness", "#selfcare", "#healthy"],
+    "tourism": ["#travel", "#tourism", "#vacation", "#holiday", "#destination", "#explore", "#adventure", "#experience", "#journey", "#wanderlust", "#getaway", "#staycation"],
+    "automotive": ["#cars", "#luxury", "#rental", "#wedding", "#event", "#celebration", "#special", "#premium", "#service", "#transportation", "#ride", "#style"]
+  },
+  "locationHashtags": {
+    "kashmir": ["#kashmir", "#srinagar", "#kashmirtourism", "#kashmirvalley", "#paradiseonearth", "#kashmirbeuty", "#incredibleindia"],
+    "india": ["#india", "#incredibleindia", "#madeinindia", "#indian", "#desi", "#bharath", "#hindustan"],
+    "sydney": ["#sydney", "#australia", "#sydneyaustralia", "#sydneyharbour", "#aussie", "#downunder"]
+  }
+}

--- a/index.html
+++ b/index.html
@@ -116,6 +116,15 @@
                                     </div>
                                 </div>
                             </div>
+
+                            <!-- AI Insights -->
+                            <div id="aiInsightsCard" class="card results-section hidden">
+                                <div class="card__body">
+                                    <h3 class="results-title">AI Insights</h3>
+                                    <p id="aiNotes" class="ai-notes hidden"></p>
+                                    <div id="aiUsage" class="ai-usage hidden"></div>
+                                </div>
+                            </div>
                         </div>
 
                         <!-- Empty State -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,961 @@
+{
+  "name": "captionsgenerator",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "captionsgenerator",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
+        "express": "^4.19.2",
+        "node-fetch": "^3.3.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "captionsgenerator",
+  "version": "1.0.0",
+  "description": "Multi-brand caption generator with AI-powered backend",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [
+    "captions",
+    "hashtags",
+    "ai",
+    "marketing"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,306 @@
+const express = require('express');
+const cors = require('cors');
+const path = require('path');
+require('dotenv').config();
+
+const fetch = global.fetch || ((...args) => import('node-fetch').then(({ default: fetchFn }) => fetchFn(...args)));
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const GOOGLE_API_KEY = process.env.GOOGLE_AI_STUDIO_API_KEY || process.env.GOOGLE_API_KEY || process.env.GOOGLE_STUDIO_API_KEY;
+const GOOGLE_MODEL = process.env.GOOGLE_AI_MODEL || process.env.GOOGLE_MODEL || 'gemini-1.5-flash-latest';
+const GOOGLE_API_BASE_URL = process.env.GOOGLE_API_BASE_URL || 'https://generativelanguage.googleapis.com';
+
+const brandData = require('./brandData.json');
+
+app.use(cors());
+app.use(express.json({ limit: '12mb' }));
+
+app.use(express.static(path.join(__dirname)));
+
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/api/generate', async (req, res) => {
+  try {
+    if (!GOOGLE_API_KEY) {
+      return res.status(500).json({ error: 'AI API key not configured on server' });
+    }
+
+    const { brandId, context, imageDataUrl } = req.body || {};
+
+    if (!brandId) {
+      return res.status(400).json({ error: 'brandId is required' });
+    }
+
+    const brand = brandData.brands.find((item) => item.id === brandId);
+    if (!brand) {
+      return res.status(404).json({ error: 'Brand not found' });
+    }
+
+    const prompt = buildPrompt({
+      brand,
+      context,
+      brandData,
+      hasImage: Boolean(imageDataUrl)
+    });
+
+    const url = `${GOOGLE_API_BASE_URL.replace(/\/$/, '')}/v1beta/models/${GOOGLE_MODEL}:generateContent?key=${GOOGLE_API_KEY}`;
+
+    const parts = [{ text: prompt }];
+    if (imageDataUrl) {
+      const parsed = parseDataUrl(imageDataUrl);
+      if (parsed) {
+        parts.push({
+          inlineData: {
+            mimeType: parsed.mimeType,
+            data: parsed.data
+          }
+        });
+      }
+    }
+
+    const payload = {
+      contents: [
+        {
+          role: 'user',
+          parts
+        }
+      ]
+    };
+
+    const aiResponse = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!aiResponse.ok) {
+      const errorText = await aiResponse.text();
+      console.error('AI request failed', aiResponse.status, errorText);
+
+      let upstreamMessage = 'AI service failed to generate content';
+      try {
+        const parsedError = JSON.parse(errorText);
+        upstreamMessage = parsedError?.error?.message || parsedError?.message || upstreamMessage;
+      } catch (parseError) {
+        if (errorText && errorText.trim().length > 0) {
+          upstreamMessage = errorText.trim();
+        }
+      }
+
+      return res.status(502).json({
+        error: `Gemini API ${aiResponse.status}: ${upstreamMessage}`,
+        upstreamStatus: aiResponse.status
+      });
+    }
+
+    const responseBody = await aiResponse.json();
+    const aiText = extractTextFromResponse(responseBody);
+
+    if (!aiText) {
+      console.error('AI response did not include text payload', responseBody);
+      return res.status(502).json({ error: 'AI service returned an empty response' });
+    }
+
+    let parsed;
+    try {
+      const cleaned = aiText.replace(/```json/gi, '').replace(/```/g, '').trim();
+      parsed = JSON.parse(cleaned);
+    } catch (error) {
+      console.error('Unable to parse AI response', error, aiText);
+      return res.status(502).json({ error: 'AI service returned malformed JSON' });
+    }
+
+    const captions = normalizeCaptions(parsed.captions, brand);
+    const hashtags = normalizeHashtags(parsed.hashtags, brand, brandData);
+
+    const metadata = {
+      model: responseBody.model,
+      usage: responseBody.usageMetadata || null,
+      notes: typeof parsed.notes === 'string' ? parsed.notes.trim() : null
+    };
+
+    res.json({ captions, hashtags, metadata });
+  } catch (error) {
+    console.error('Unexpected error while generating content', error);
+    res.status(500).json({ error: 'Unexpected server error during generation' });
+  }
+});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Caption generator server running on http://localhost:${PORT}`);
+  });
+}
+
+function parseDataUrl(dataUrl) {
+  if (typeof dataUrl !== 'string') return null;
+  const matches = dataUrl.match(/^data:(.*?);base64,(.*)$/);
+  if (!matches || matches.length < 3) return null;
+  return {
+    mimeType: matches[1],
+    data: matches[2]
+  };
+}
+
+function buildPrompt({ brand, context, brandData, hasImage }) {
+  const industryKey = getIndustryKey(brand.id);
+  const locationKey = getLocationKey(brand.id);
+
+  const industryHashtags = industryKey ? (brandData.industryHashtags[industryKey] || []) : [];
+  const locationHashtags = locationKey ? (brandData.locationHashtags[locationKey] || []) : [];
+  const trending = brandData.trendingHashtags2025 || [];
+
+  const contextSection = context && context.trim().length > 0
+    ? `The marketer provided the following context to inspire the copy:\n"""${context.trim()}"""`
+    : 'No additional context was provided. Create an evergreen yet timely update that still feels specific and engaging.';
+
+  const imageSection = hasImage
+    ? 'An image asset is attached to this request. Reference likely visual storytelling cues in the captions without inventing unrealistic details.'
+    : 'No image asset was provided. Focus on copy that stands on its own.';
+
+  return `You are an expert social media copywriter helping a marketing team create Instagram-ready captions and hashtag sets. Use the brand information and supporting hashtag libraries below to produce polished results. Always reply with valid JSON that matches the requested schema and do not wrap the JSON in Markdown fences. Avoid angle brackets, trailing comments, or any additional prose outside of the JSON.\n\nBrand Information:\n- Name: ${brand.name}\n- Description: ${brand.description}\n- Industry: ${brand.industry}\n- Tone: ${brand.tone}\n- Target audience: ${brand.target}\n- Key messages: ${brand.keywords.join(', ')}\n- Website: ${brand.website || 'N/A'}\n- Signature hashtags: ${brand.hashtags.join(' ')}\n- Sample captions: ${brand.sampleCaptions.join(' | ')}\n\n${contextSection}\n${imageSection}\n\nReference Hashtag Libraries:\n- Industry pool (${industryKey || 'general'}): ${industryHashtags.join(' ')}\n- Location pool (${locationKey || 'general'}): ${locationHashtags.join(' ')}\n- 2025 trending inspiration: ${trending.join(' ')}\n\nReturn JSON in the following structure:\n{\n  "captions": [\n    { "type": "Short", "text": "25-60 character hook caption" },\n    { "type": "Medium", "text": "1-2 sentence caption with strong CTA" },\n    { "type": "Long", "text": "Multi-sentence storytelling caption" },\n    { "type": "Brand Style", "text": "Caption that mirrors the brand voice" }\n  ],\n  "hashtags": [\n    { "category": "Brand Specific", "hashtags": ["#tag", "#tag"] },\n    { "category": "Industry Relevant", "hashtags": ["#tag", "#tag"] },\n    { "category": "Location Based", "hashtags": ["#tag", "#tag"] },\n    { "category": "Trending", "hashtags": ["#tag", "#tag"] }\n  ],\n  "notes": "One sentence with optional strategic guidance."\n}\n\nRules:\n1. Populate every caption slot. Types must match exactly (Short, Medium, Long, Brand Style).\n2. Captions should follow the brand tone and include emojis where they feel natural.\n3. Each hashtag list must contain 8-12 unique entries that begin with '#'. Use brand, industry, location, and trending pools as inspiration while avoiding duplicates across sets.\n4. The response must be valid JSON with double quotes around every string.`;
+}
+
+function getIndustryKey(brandId) {
+  const map = {
+    furniturehub12: 'furniture',
+    asian_bazaar: 'furniture',
+    exportofindia: 'furniture',
+    blissofwellness: 'wellness',
+    hotel_kspalace: 'tourism',
+    houseboat_holidays_kashmir: 'tourism',
+    valleyweddingcars: 'automotive'
+  };
+  return map[brandId] || null;
+}
+
+function getLocationKey(brandId) {
+  const map = {
+    hotel_kspalace: 'kashmir',
+    houseboat_holidays_kashmir: 'kashmir',
+    valleyweddingcars: 'kashmir',
+    asian_bazaar: 'sydney'
+  };
+  return map[brandId] || 'india';
+}
+
+function normalizeCaptions(captions, brand) {
+  if (!Array.isArray(captions)) {
+    return buildCaptionFallback(brand);
+  }
+
+  const cleaned = captions
+    .map((entry) => ({
+      type: typeof entry.type === 'string' ? entry.type.trim() : 'Caption',
+      text: typeof entry.text === 'string' ? entry.text.trim() : ''
+    }))
+    .filter((entry) => entry.text.length > 0);
+
+  if (cleaned.length === 0) {
+    return buildCaptionFallback(brand);
+  }
+
+  const expectedTypes = ['Short', 'Medium', 'Long', 'Brand Style'];
+  const prioritized = [];
+
+  expectedTypes.forEach((type) => {
+    const matchIndex = cleaned.findIndex((entry) => entry.type.toLowerCase() === type.toLowerCase());
+    if (matchIndex >= 0) {
+      prioritized.push({ type, text: cleaned[matchIndex].text });
+    }
+  });
+
+  cleaned.forEach((entry) => {
+    const exists = prioritized.some((item) => item.text === entry.text);
+    if (!exists) {
+      prioritized.push(entry);
+    }
+  });
+
+  return prioritized;
+}
+
+function normalizeHashtags(hashtags, brand, brandData) {
+  if (!Array.isArray(hashtags)) {
+    return buildHashtagFallback(brand, brandData);
+  }
+
+  const cleaned = hashtags
+    .map((entry) => ({
+      category: typeof entry.category === 'string' ? entry.category.trim() : 'General',
+      hashtags: Array.isArray(entry.hashtags)
+        ? entry.hashtags.map((tag) => sanitizeHashtag(tag)).filter(Boolean)
+        : []
+    }))
+    .filter((entry) => entry.hashtags.length > 0);
+
+  if (cleaned.length === 0) {
+    return buildHashtagFallback(brand, brandData);
+  }
+
+  return cleaned;
+}
+
+function sanitizeHashtag(tag) {
+  if (typeof tag !== 'string') return null;
+  const cleaned = tag.trim();
+  if (!cleaned) return null;
+  return cleaned.startsWith('#') ? cleaned : `#${cleaned.replace(/^#+/, '')}`;
+}
+
+function buildCaptionFallback(brand) {
+  const sample = brand.sampleCaptions && brand.sampleCaptions.length > 0
+    ? brand.sampleCaptions[0]
+    : `Discover ${brand.name}`;
+  return [
+    { type: 'Brand Style', text: sample }
+  ];
+}
+
+function buildHashtagFallback(brand, brandData) {
+  const industryKey = getIndustryKey(brand.id);
+  const locationKey = getLocationKey(brand.id);
+  const fallbackSets = [
+    {
+      category: 'Brand Specific',
+      hashtags: brand.hashtags.slice(0, 10)
+    },
+    {
+      category: 'Industry Relevant',
+      hashtags: (industryKey ? brandData.industryHashtags[industryKey] : []).slice(0, 10)
+    },
+    {
+      category: 'Location Based',
+      hashtags: (locationKey ? brandData.locationHashtags[locationKey] : []).slice(0, 10)
+    }
+  ];
+
+  const trending = (brandData.trendingHashtags2025 || []).slice(0, 10);
+  if (trending.length) {
+    fallbackSets.push({
+      category: 'Trending',
+      hashtags: trending
+    });
+  }
+
+  return fallbackSets;
+}
+
+function extractTextFromResponse(responseBody) {
+  const candidate = responseBody?.candidates?.[0];
+  if (!candidate || !candidate.content || !Array.isArray(candidate.content.parts)) {
+    return null;
+  }
+
+  return candidate.content.parts
+    .map((part) => part.text || '')
+    .join('')
+    .trim();
+}
+
+module.exports = app;

--- a/style.css
+++ b/style.css
@@ -1115,6 +1115,22 @@ select.form-control {
   border: 1px solid var(--color-card-border);
 }
 
+/* AI Insights */
+.ai-notes {
+  font-size: var(--font-size-md);
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+}
+
+.ai-usage {
+  margin-top: var(--space-12);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-12);
+}
+
 .hashtag-set-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add an Express backend that calls Google AI Studio (Gemini) to generate captions, hashtags, and metadata with fallbacks
- load brand configuration from a shared JSON file and update the frontend to call the AI endpoint, surface usage insights, and handle image uploads
- document setup with environment template, dependencies, and startup instructions for the new server
- default Gemini calls to `gemini-1.5-flash-latest`, allow overriding via environment variables, and forward detailed upstream error messages to avoid 404 failures

## Testing
- node -e "require('./server')"

------
https://chatgpt.com/codex/tasks/task_b_68ce99d5dbb4832985e2c4d6b404bae8